### PR TITLE
feat(scripts): Airtableスキーマ同期スクリプトを追加

### DIFF
--- a/docs/Airtable_Schema_Summary.md
+++ b/docs/Airtable_Schema_Summary.md
@@ -1,6 +1,6 @@
 # Airtable Database Schema Summary
 
-このドキュメントは、あなたのAirtableベースのスキーマ（テーブル、フィールド、およびその型）をまとめたものです。
+_Last updated: 2025-07-01T22:17:03.527052Z_
 
 ---
 
@@ -11,9 +11,8 @@
 - **エリア**: singleSelect
 - **圃場名**: multilineText
 - **面積(ha)**: number
-- **メモ**: singleLineText
-- **作つけ計画**: singleLineText
 - **作付詳細**: multipleRecordLinks
+- **メモ**: singleLineText
 - **肥料管理**: singleLineText
 - **大豆作付計画**: singleLineText
 - **大豆播種管理**: singleLineText
@@ -94,6 +93,8 @@
 - **ステータス**: singleSelect
 - **予定日**: date
 - **実施日**: date
+- **使用資材**: multipleRecordLinks
+- **資材名 (from 使用資材)**: multipleLookupValues
 - **メモ**: aiText
 
 ---
@@ -111,6 +112,7 @@
 - **施用方法**: singleLineText
 - **保管場所**: singleLineText
 - **メモ**: multilineText
+- **作業タスク**: multipleRecordLinks
 
 ---
 
@@ -144,20 +146,6 @@
 
 ---
 
-## Table: 収穫ログ (ID: tblU8EUlRGyNK9blV)
-
-### Fields:
-- **収穫日**: date
-- **作物名**: singleLineText
-- **圃場名**: singleLineText
-- **サイズ**: singleSelect
-- **収穫量(kg)**: number
-- **単価(円/kg)**: currency
-- **売上**: number
-- **メモ**: multilineText
-
----
-
 ## Table: ナレッジベース (ID: tblYgwLKYh7XlK08z)
 
 ### Fields:
@@ -169,3 +157,16 @@
 
 ---
 
+## Table: 収穫ログ (ID: tblU8EUlRGyNK9blV)
+
+### Fields:
+- **収穫日**: date
+- **作物名**: singleLineText
+- **圃場名**: singleLineText
+- **サイズ**: singleSelect
+- **収穫量(個)**: number
+- **単価(円/個)**: currency
+- **売上**: number
+- **メモ**: multilineText
+
+---

--- a/scripts/generate_airtable_schema.py
+++ b/scripts/generate_airtable_schema.py
@@ -1,0 +1,62 @@
+"""generate_airtable_schema.py
+Airtable Metadata API を利用して、指定された Base 内のすべてのテーブルと
+フィールド情報を取得し、docs/Airtable_Schema_Summary.md を自動生成するスクリプト。
+
+メタデータ API は Personal Access Token (PAT) でのみ利用できます。
+`.env` に下記の環境変数を追加してください。
+
+AIRTABLE_API_KEY   = pat... (scope: schema.bases:read)
+AIRTABLE_BASE_ID   = app...
+
+使い方:
+    python scripts/generate_airtable_schema.py
+"""
+
+import os
+import sys
+import requests
+from pathlib import Path
+from datetime import datetime
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.getenv("AIRTABLE_API_KEY")
+BASE_ID = os.getenv("AIRTABLE_BASE_ID")
+OUTPUT_PATH = Path("docs/Airtable_Schema_Summary.md")
+
+if not API_KEY or not BASE_ID:
+    sys.exit("AIRTABLE_API_KEY または AIRTABLE_BASE_ID が .env に設定されていません。")
+
+METADATA_URL = f"https://api.airtable.com/v0/meta/bases/{BASE_ID}/tables"
+HEADERS = {"Authorization": f"Bearer {API_KEY}"}
+
+resp = requests.get(METADATA_URL, headers=HEADERS, timeout=30)
+if resp.status_code != 200:
+    sys.exit(f"Metadata API からスキーマを取得できませんでした: {resp.status_code} {resp.text}")
+
+data = resp.json()
+
+lines = [
+    "# Airtable Database Schema Summary",
+    "",
+    f"_Last updated: {datetime.utcnow().isoformat()}Z_",
+    "",
+    "---",
+    "",
+]
+
+for table in data.get("tables", []):
+    t_name = table["name"]
+    t_id = table["id"]
+    lines.append(f"## Table: {t_name} (ID: {t_id})\n")
+    lines.append("### Fields:")
+    for field in table.get("fields", []):
+        fname = field["name"]
+        ftype = field["type"]
+        lines.append(f"- **{fname}**: {ftype}")
+    lines.append("\n---\n")
+
+OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+OUTPUT_PATH.write_text("\n".join(lines), encoding="utf-8")
+print(f"Schema summary written to {OUTPUT_PATH}")


### PR DESCRIPTION
Airtable Metadata API を使用して Base 全体のスキーマを取得し、
docs/Airtable_Schema_Summary.md を自動生成するスクリプトを追加しました。

## 変更点
- scripts/generate_airtable_schema.py 追加
- docs/Airtable_Schema_Summary.md を自動生成・更新